### PR TITLE
Update rustup.sh URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ For technical details, see [ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ### Prerequisites
 
-- **Rust**: Install via [https://rustup.sh/](https://rustup.sh/)
+- **Rust**: Install via [https://rustup.rs/](https://rustup.rs/)
   ```bash
   # After installing Rust, add the x86_64 target for universal binary support
   rustup target add x86_64-apple-darwin


### PR DESCRIPTION
The `README.md` file was updated.

*   The Rust installation URL was corrected from `https://rustup.sh/` to `https://rustup.rs/`.
*   This change ensures the documentation points to the current and official installation source for Rust.